### PR TITLE
Remove Gemini timeout workaround

### DIFF
--- a/src/star_chamber/transport.py
+++ b/src/star_chamber/transport.py
@@ -115,19 +115,11 @@ async def send_to_provider(
     if config.api_base is not None:
         kwargs["api_base"] = config.api_base
 
-    # TODO: Remove gemini branch when mozilla-ai/any-llm#901 and #902 are resolved.
-    # Gemini rejects request-level timeout kwargs and platform mode breaks
-    # client_args routing. Use asyncio.wait_for as an external timeout instead.
-    use_external_timeout = timeout is not None and config.provider == "gemini"
-    if timeout is not None and not use_external_timeout:
+    if timeout is not None:
         kwargs["timeout"] = timeout
 
     try:
-        coro = any_llm.acompletion(**kwargs)
-        if use_external_timeout:
-            response = await asyncio.wait_for(coro, timeout=timeout)
-        else:
-            response = await coro
+        response = await any_llm.acompletion(**kwargs)
     except TimeoutError:
         return ProviderResponse(
             provider=config.provider,

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -239,8 +239,8 @@ class TestSendToProvider:
         assert result.success is False
         assert "no response" in result.error.lower() or "empty" in result.error.lower()
 
-    def test_gemini_timeout_not_passed_as_kwarg(self):
-        """Gemini rejects request-level timeout; it must not appear in kwargs."""
+    def test_gemini_timeout_passed_as_kwarg(self):
+        """Gemini receives timeout as a direct request kwarg (fixed in any-llm-sdk 1.11.0)."""
         mock_module = _make_mock_any_llm()
         config = ProviderConfig(provider="gemini", model="gemini-2.0-flash")
 
@@ -248,24 +248,7 @@ class TestSendToProvider:
             asyncio.run(send_to_provider(config, "Review this.", timeout=30.0))
 
         call_kwargs = mock_module.acompletion.call_args.kwargs
-        assert "timeout" not in call_kwargs
-        assert "client_args" not in call_kwargs
-
-    def test_gemini_timeout_cancels_on_expiry(self):
-        """Gemini timeout uses asyncio.wait_for which raises TimeoutError."""
-
-        async def _slow_completion(**kwargs):
-            await asyncio.sleep(10)
-
-        mock_module = _make_mock_any_llm()
-        mock_module.acompletion = AsyncMock(side_effect=_slow_completion)  # type: ignore[attr-defined]
-        config = ProviderConfig(provider="gemini", model="gemini-2.0-flash")
-
-        with patch.dict(sys.modules, {"any_llm": mock_module}):
-            result = asyncio.run(send_to_provider(config, "Review this.", timeout=0.05))
-
-        assert result.success is False
-        assert "timeout" in result.error.lower()
+        assert call_kwargs["timeout"] == 30.0
 
     def test_non_gemini_timeout_uses_request_kwarg(self):
         """Non-gemini providers receive timeout as a direct request kwarg."""
@@ -277,7 +260,6 @@ class TestSendToProvider:
 
         call_kwargs = mock_module.acompletion.call_args.kwargs
         assert call_kwargs["timeout"] == 30.0
-        assert "client_args" not in call_kwargs
 
 
 # -- fan_out ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove `asyncio.wait_for` workaround for Gemini timeout handling — upstream fixes in any-llm-sdk 1.11.0 (mozilla-ai/any-llm#901, #902) make it unnecessary
- Gemini now receives `timeout` as a standard request kwarg like all other providers
- Update tests to reflect the simplified code path

## Context
Star-chamber had a Gemini-specific branch that avoided passing `timeout` as a kwarg (Gemini rejected it) and used `asyncio.wait_for` instead. The platform mode also had a `client_args` routing bug. Both were fixed upstream in any-llm-sdk 1.11.0, which is now the minimum version after #8.

## Test plan
- [x] All 195 tests pass (1 removed — tested the workaround's `asyncio.wait_for` path)
- [x] New `test_gemini_timeout_passed_as_kwarg` confirms Gemini gets timeout like other providers
- [x] Linter and formatter pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined timeout handling across LLM providers to ensure consistent behaviour and improved reliability in completion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->