### PR TITLE
Fix Otari auth: let SDK auto-detect credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ Instead of managing API keys per provider, you can route all non-local providers
 
 In Otari mode, Otari — not the SDK — picks the upstream provider, so the per-provider `provider` field becomes a label. Otari expects the `model` field to use a `provider:model` prefix such as `"openai:gpt-4o"`; consult Otari's documentation for its model-naming convention.
 
-`api_base` and `api_key` may also be omitted from the config, in which case they are resolved from the `OTARI_API_BASE` and `OTARI_API_KEY` environment variables. Both fields also support `${ENV_VAR}` references.
-
-For Bearer-token auth against a hosted Otari platform, omit `api_key` and set the `OTARI_PLATFORM_TOKEN` environment variable instead — the Otari client detects it and switches to platform mode automatically.
+`api_base` and `api_key` may be omitted from the config; when omitted, the SDK's OtariProvider auto-detects credentials from its own env vars (`OTARI_AI_TOKEN` for platform mode, `GATEWAY_API_KEY` for self-hosted). Both fields also support `${ENV_VAR}` references.
 
 Providers marked `"local": true` always bypass Otari and continue to use their own `api_base`.
 

--- a/src/star_chamber/transport.py
+++ b/src/star_chamber/transport.py
@@ -239,9 +239,10 @@ def resolve_otari(otari: OtariConfig | None) -> OtariConfig | None:
 
     Returns a new OtariConfig; never mutates input.  Returns None when
     ``otari`` is None.  An explicit ``api_base`` or ``api_key`` may use a
-    ``${ENV_VAR}`` reference, which is expanded.  When either is None, it
-    falls back to the ``OTARI_API_BASE`` / ``OTARI_API_KEY`` environment
-    variable; an unset variable leaves the field None.
+    ``${ENV_VAR}`` reference, which is expanded.  When either field is
+    None, it stays None so the SDK's OtariProvider can auto-detect
+    credentials from its own env vars (OTARI_AI_TOKEN, GATEWAY_API_KEY,
+    etc.).
 
     Args:
         otari: Optional Otari configuration.
@@ -252,11 +253,8 @@ def resolve_otari(otari: OtariConfig | None) -> OtariConfig | None:
     if otari is None:
         return None
 
-    api_base = otari.api_base
-    api_base = os.environ.get("OTARI_API_BASE") if api_base is None else _expand_env_var(api_base)
-
-    api_key = otari.api_key
-    api_key = os.environ.get("OTARI_API_KEY") if api_key is None else _expand_env_var(api_key)
+    api_base = None if otari.api_base is None else _expand_env_var(otari.api_base)
+    api_key = None if otari.api_key is None else _expand_env_var(otari.api_key)
 
     return OtariConfig(api_base=api_base, api_key=api_key)
 

--- a/src/star_chamber/types.py
+++ b/src/star_chamber/types.py
@@ -35,10 +35,12 @@ class OtariConfig:
     all routed providers.
 
     Attributes:
-        api_base: Otari base URL or ${ENV_VAR} reference. Falls back to the
-            OTARI_API_BASE environment variable when None.
-        api_key: Otari API key or ${ENV_VAR} reference. Falls back to the
-            OTARI_API_KEY environment variable when None.
+        api_base: Otari base URL or ${ENV_VAR} reference. When None, the
+            SDK's OtariProvider resolves the base URL from its own env vars.
+        api_key: Otari API key or ${ENV_VAR} reference. When None, the
+            SDK's OtariProvider auto-detects credentials from its own env
+            vars (OTARI_AI_TOKEN for platform mode, GATEWAY_API_KEY for
+            self-hosted mode).
     """
 
     api_base: str | None = None

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -401,27 +401,8 @@ class TestResolveOtari:
         result = resolve_otari(gw)
         assert result is not gw
 
-    def test_api_base_falls_back_to_env_when_none(self, monkeypatch):
-        monkeypatch.setenv("OTARI_API_BASE", "https://env-gw.example/v1")
-        gw = OtariConfig(api_base=None, api_key="literal")  # pragma: allowlist secret
-
-        result = resolve_otari(gw)
-
-        assert result is not None
-        assert result.api_base == "https://env-gw.example/v1"
-
-    def test_api_key_falls_back_to_env_when_none(self, monkeypatch):
-        monkeypatch.setenv("OTARI_API_KEY", "env-gw-key")
-        gw = OtariConfig(api_base="https://gw.example/v1", api_key=None)
-
-        result = resolve_otari(gw)
-
-        assert result is not None
-        assert result.api_key == "env-gw-key"  # pragma: allowlist secret
-
-    def test_unset_env_leaves_fields_none(self, monkeypatch):
-        monkeypatch.delenv("OTARI_API_BASE", raising=False)
-        monkeypatch.delenv("OTARI_API_KEY", raising=False)
+    def test_none_fields_stay_none_for_sdk_auto_detection(self):
+        """None fields are left for the SDK's OtariProvider to resolve."""
         gw = OtariConfig()  # both None
 
         result = resolve_otari(gw)
@@ -430,9 +411,7 @@ class TestResolveOtari:
         assert result.api_base is None
         assert result.api_key is None
 
-    def test_explicit_values_take_precedence_over_env(self, monkeypatch):
-        monkeypatch.setenv("OTARI_API_BASE", "https://env-gw.example/v1")
-        monkeypatch.setenv("OTARI_API_KEY", "env-gw-key")
+    def test_explicit_values_are_preserved(self):
         gw = OtariConfig(api_base="https://explicit.example/v1", api_key="explicit-key")  # pragma: allowlist secret
 
         result = resolve_otari(gw)


### PR DESCRIPTION
## Summary

- Removed invented `OTARI_API_KEY` / `OTARI_API_BASE` env var fallbacks from `resolve_otari()` — these shadowed the SDK's own credential resolution (`OTARI_AI_TOKEN` for platform mode, `GATEWAY_API_KEY` for self-hosted).
- When config fields are `None`, they stay `None` so `OtariProvider` handles auto-detection from its canonical env vars.
- Explicit `${VAR}` references in config still expand as before.
- Updated README to document the new behavior.

## Test plan

- [x] All 216 tests pass
- [x] Lint clean
- [x] Verified `None` fields pass through unchanged
- [x] Verified explicit values and `${VAR}` expansion still work
