### PR TITLE
docs: correct Otari platform credential env var in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Instead of managing API keys per provider, you can route all non-local providers
 
 In Otari mode, Otari — not the SDK — picks the upstream provider, so the per-provider `provider` field becomes a label. Otari expects the `model` field to use a `provider:model` prefix such as `"openai:gpt-4o"`; consult Otari's documentation for its model-naming convention.
 
-`api_base` and `api_key` may be omitted from the config; when omitted, the SDK's OtariProvider auto-detects credentials from its own env vars (`OTARI_AI_TOKEN` for platform mode, `GATEWAY_API_KEY` for self-hosted). Both fields also support `${ENV_VAR}` references.
+`api_base` and `api_key` may be omitted from the config; when omitted, the SDK's OtariProvider auto-detects credentials from its own env vars: `OTARI_API_KEY` for the hosted otari.ai platform (`Authorization: Bearer`, matching otari.ai's docs), or `GATEWAY_API_KEY` for a self-hosted gateway (`Otari-Key` header). `OTARI_AI_TOKEN` is also accepted as a platform-token alias. Both fields also support `${ENV_VAR}` references.
 
 Providers marked `"local": true` always bypass Otari and continue to use their own `api_base`.
 


### PR DESCRIPTION
## Summary

Fixes the Otari env-var paragraph in the README, which named `OTARI_AI_TOKEN` as the hosted-platform credential. Since the dependency floor is `any-llm-sdk>=1.23.0`, that is outdated and internally inconsistent — the config example directly above already uses `${OTARI_API_KEY}`.

any-llm-sdk 1.23.0 made `OTARI_API_KEY` the primary hosted-platform token (sent as `Authorization: Bearer`), matching otari.ai's own quickstart. `OtariProvider._resolve_platform_token()` now resolves `OTARI_API_KEY` first; `OTARI_AI_TOKEN` remains only a fallback alias.

## Change

`README.md` — the env-var paragraph now documents:
- `OTARI_API_KEY` for the hosted otari.ai platform (`Authorization: Bearer`)
- `GATEWAY_API_KEY` for a self-hosted gateway (`Otari-Key` header)
- `OTARI_AI_TOKEN` as an accepted platform-token alias

This aligns the paragraph with the config example, otari.ai's docs, and any-llm-sdk 1.23.0.

## Verification

Checked against the installed source (`any_llm/providers/otari/otari.py`, v1.23.0): `ENV_API_KEY_NAME = "OTARI_API_KEY"` and `_resolve_platform_token()` resolves `OTARI_API_KEY` before `OTARI_AI_TOKEN`. Floor is `any-llm-sdk>=1.23.0`, installed `1.23.0`.

Fixes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified automatic detection of Otari credentials from environment variables when configuration values are omitted.
  - Documented `OTARI_AI_TOKEN` as an accepted platform-token alias.
  - Added support guidance for `${ENV_VAR}` references in API base and key settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->